### PR TITLE
Omit empty string parameters

### DIFF
--- a/cs.py
+++ b/cs.py
@@ -55,7 +55,7 @@ def cs_encode(value):
 
 def transform(params):
     for key, value in list(params.items()):
-        if value is None:
+        if value is None or value == "":
             params.pop(key)
             continue
         if isinstance(value, string_type):


### PR DESCRIPTION
This patch omits parameters if values are empty string.

Now cs doesn't generate correct signature when empty strings are passed.
This causes  ansible's  cloudstack inventory script errors when project id is not specified. 