### PR TITLE
handle non json response more user friendly

### DIFF
--- a/cs.py
+++ b/cs.py
@@ -123,7 +123,16 @@ class CloudStack(object):
         else:
             kw['data'] = kwargs
         response = getattr(requests, self.method)(self.endpoint, **kw)
-        data = response.json()
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            msg = "Make sure endpoint URL '%s' is correct." % self.endpoint
+            raise CloudStackException(
+                "HTTP {0} response from CloudStack".format(
+                    response.status_code), response, "%s. " % str(e) + msg
+                )
+
         [key] = data.keys()
         data = data[key]
         if response.status_code != 200:


### PR DESCRIPTION
Dealing with users about a wrong configured endpoint url is annoying. :) Users get a ValueError for a non json response. I tried to make it more user friendly if endpoint is wrong configured.

~~~
python cs.py listVirtualMachines
Cloudstack error:
"No JSON object could be decoded. Make sure endpoint URL 'https://ma-cloud.swisstxt.ch/client/apis' is correct."%
~~~

