### PR TITLE
wait async job until jobstatus != 0 

### DIFF
--- a/cs.py
+++ b/cs.py
@@ -243,7 +243,7 @@ def main():
         while True:
             try:
                 res = cs.queryAsyncJobResult(**response)
-                if res['jobprocstatus'] == 0:
+                if res['jobstatus'] != 0:
                     response = res
                     break
                 time.sleep(3)


### PR DESCRIPTION
This patch changes how to wait an async job.

It waits for the job until `jobstatus != 0` because `jobprocstatus` can be 0 even if the job is still processing.
cs can't get jobresult if the job takes more than 3 seconds. 

```sh
$ cs deployVirtualMachine zoneid=baf86a6e-4e3b-428e-8fd0-7fda43e468d4 serviceofferingid=e01a9f32-55c4-4c0d-9b7c-d49a3ccfd3f6 templateid=ec45fa26-e5d0-45a7-b57d-0c3f8e36ff3b
Polling result... ^C to abort
{
  "accountid": "6c9ce4be-ed0b-477b-aa76-f0cb1b7a200b", 
  "cmd": "org.apache.cloudstack.api.command.user.vm.DeployVMCmd", 
  "created": "2015-11-25T09:14:08+0900", 
  "jobid": "609d8aed-95e5-4393-979b-a7f954ef0682", 
  "jobinstanceid": "f09c9845-99d2-44d4-85c2-857b01307df2", 
  "jobinstancetype": "VirtualMachine", 
  "jobprocstatus": 0, 
  "jobresultcode": 0, 
  "jobstatus": 0, 
  "userid": "c8be3f37-1175-475b-8f67-08bb33d6f6ea"
}
```

I tested on CCP 4.3 but this will work ACS and other versions because `cloudmonkey` also uses `jobstatus` to wait async jobs.

