### PR TITLE
Fix output

### DIFF
--- a/cs.py
+++ b/cs.py
@@ -284,6 +284,7 @@ def main():
     if pygments and sys.stdout.isatty():
         data = pygments.highlight(data, JsonLexer(), TerminalFormatter())
     sys.stdout.write(data)
+    sys.stdout.write('\n')
     sys.exit(int(not ok))
 
 


### PR DESCRIPTION
Fix 2 small things for the output:
- ~~stdout instead of stderr for the waiting message~~
- append a `\n` after the result output to not have the last `} ` on the same line as the prompt