### PR TITLE
client: support sending dict

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-
 import base64
 import hashlib
 import hmac
@@ -57,10 +56,12 @@ def transform(params):
             continue
         elif isinstance(value, integer_types):
             params[key] = text_type(value)
-        elif isinstance(value, (list, tuple, set)):
+        elif isinstance(value, (list, tuple, set, dict)):
             if not value:
                 params.pop(key)
             else:
+                if isinstance(value, dict):
+                    value = [value]
                 if isinstance(value, set):
                     value = list(value)
                 if not isinstance(value[0], dict):
@@ -68,8 +69,9 @@ def transform(params):
                 else:
                     params.pop(key)
                     for index, val in enumerate(value):
-                        for k, v in val.items():
-                            params["%s[%d].%s" % (key, index, k)] = v
+                        for name, v in val.items():
+                            k = "%s[%d].%s" % (key, index, name)
+                            params[k] = text_type(v)
         else:
             raise ValueError(type(value))
     return params

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+from __future__ import unicode_literals
+
 import os
 import sys
 
@@ -182,16 +184,37 @@ class RequestTest(TestCase):
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(foo=["foo", "bar"],
-                               bar=[{'baz': 'blah', 'foo': 'meh'}])
+                               bar=[{'baz': 'blah', 'foo': 1000}])
         get.assert_called_once_with(
             'localhost', timeout=10, cert=None, verify=True, params={
                 'command': 'listVirtualMachines',
                 'response': 'json',
-                'bar[0].foo': 'meh',
+                'bar[0].foo': '1000',
                 'bar[0].baz': 'blah',
                 'foo': 'foo,bar',
                 'apiKey': 'foo',
-                'signature': 'UGUVEfCOfGfOlqoTj1D2m5adr2g=',
+                'signature': '5RnA+jzX2BllTd85GwNrjoqxHl4=',
+            },
+        )
+
+    @patch("requests.get")
+    def test_transform_dict(self, get):
+        cs = CloudStack(endpoint='localhost', key='foo', secret='bar')
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {
+            'scalevirtualmachineresponse': {},
+        }
+        cs.scaleVirtualMachine(id='a',
+                               details={'cpunumber': 1000, 'memory': '640k'})
+        get.assert_called_once_with(
+            'localhost', timeout=10, cert=None, verify=True, params={
+                'command': 'scaleVirtualMachine',
+                'response': 'json',
+                'id': 'a',
+                'details[0].cpunumber': '1000',
+                'details[0].memory': '640k',
+                'apiKey': 'foo',
+                'signature': 'ZNl66z3gFhnsx2Eo3vvCIM0kAgI=',
             },
         )
 


### PR DESCRIPTION
scaleVirtualMachine requires to send key/value for the details... this wasn't supported.

https://cloudstack.apache.org/api/apidocs-4.7/user/scaleVirtualMachine.html

Also fixes the signature for non-string values, e.g. int
  
  