### PR TITLE
fix: quiet mode

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -90,11 +90,11 @@ def main():
         if not options.quiet:
             sys.stderr.write("Cloudstack error: HTTP response "
                              "{0}\n".format(response.status_code))
-            try:
-                data = json.loads(response.text)
-                sys.stderr.write(_format_json(data))
-            except json.decoder.JSONDecodeError:
-                sys.stderr.write(response.text)
+
+        try:
+            response = json.loads(response.text)
+        except json.decoder.JSONDecodeError:
+            sys.stderr.write(response.text)
             sys.stderr.write("\n")
             sys.exit(1)
 


### PR DESCRIPTION
I was trying to `jq` the error output, but got bitten by the fact that the JSON output was displayed on `stderr`. Then activating the `quiet` revealed the pink mast.

**Before**

```
$ cs -q listAsyncJobs startdate="2018-01-08T08:10:00+0100" 
Traceback (most recent call last):
  File "/home/yoan/exoscale/cs/venv/bin/cs", line 11, in <module>
    load_entry_point('cs', 'console_scripts', 'cs')()
  File "/home/yoan/exoscale/cs/cs/__init__.py", line 118, in main
    sys.stdout.write(_format_json(response))
  File "/home/yoan/exoscale/cs/cs/__init__.py", line 37, in _format_json
    output = json.dumps(data, indent=2, sort_keys=True)
  File "/usr/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/lib/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'Response' is not JSON serializable
```

**After**
```
$ cs -q listAsyncJobs startdate="2018-01-08T08:10:00+0100"
{
  "listasyncjobsresponse": {
    "cserrorcode": 9999,
    "errorcode": 431,
    "errortext": "Unable to parse date 2018-01-08T08:10:00+0100 for command listasyncjobs, please pass dates in the format mentioned in the api documentation",
    "uuidList": []
  }
}
```