### PR TITLE
Allow byte-encoded userdata

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -23,10 +23,12 @@ if PY2:
     text_type = unicode  # noqa
     string_type = basestring  # noqa
     integer_types = int, long  # noqa
+    binary_type = str
 else:
     text_type = str
     string_type = str
     integer_types = int
+    binary_type = bytes
 
 if sys.version_info >= (3, 5):
     try:
@@ -54,7 +56,7 @@ def transform(params):
             continue
         if isinstance(value, string_type):
             continue
-        if key == "userdata" and isinstance(value, bytes):
+        elif key == "userdata" and isinstance(value, binary_type):
             continue
         elif isinstance(value, integer_types):
             params[key] = text_type(value)

--- a/cs/client.py
+++ b/cs/client.py
@@ -54,6 +54,8 @@ def transform(params):
             continue
         if isinstance(value, string_type):
             continue
+        if key == "userdata" and isinstance(value, bytes):
+            continue
         elif isinstance(value, integer_types):
             params[key] = text_type(value)
         elif isinstance(value, (list, tuple, set, dict)):

--- a/cs/client.py
+++ b/cs/client.py
@@ -56,7 +56,7 @@ def transform(params):
             continue
         if isinstance(value, string_type):
             continue
-        elif key == "userdata" and isinstance(value, binary_type):
+        elif isinstance(value, binary_type):
             continue
         elif isinstance(value, integer_types):
             params[key] = text_type(value)

--- a/cs/client.py
+++ b/cs/client.py
@@ -54,9 +54,7 @@ def transform(params):
         if value is None:
             params.pop(key)
             continue
-        if isinstance(value, string_type):
-            continue
-        elif isinstance(value, binary_type):
+        if isinstance(value, (string_type, binary_type)):
             continue
         elif isinstance(value, integer_types):
             params[key] = text_type(value)

--- a/tests.py
+++ b/tests.py
@@ -187,7 +187,8 @@ class RequestTest(TestCase):
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(foo=["foo", "bar"],
-                               bar=[{'baz': 'blah', 'foo': 1000}])
+                               bar=[{'baz': 'blah', 'foo': 1000}],
+                               bytes_param='blah'.encode('utf-8'))
         get.assert_called_once_with(
             'localhost', timeout=10, cert=None, verify=True, params={
                 'command': 'listVirtualMachines',
@@ -195,8 +196,9 @@ class RequestTest(TestCase):
                 'bar[0].foo': '1000',
                 'bar[0].baz': 'blah',
                 'foo': 'foo,bar',
+                'bytes_param': 'blah'.encode('utf-8'),
                 'apiKey': 'foo',
-                'signature': '5RnA+jzX2BllTd85GwNrjoqxHl4=',
+                'signature': 'ImJ/5F0P2RDL7yn4LdLnGcEx5WE=',
             },
         )
 

--- a/tests.py
+++ b/tests.py
@@ -188,7 +188,7 @@ class RequestTest(TestCase):
         }
         cs.listVirtualMachines(foo=["foo", "bar"],
                                bar=[{'baz': 'blah', 'foo': 1000}],
-                               bytes_param='blah'.encode('utf-8'))
+                               bytes_param=b'blah')
         get.assert_called_once_with(
             'localhost', timeout=10, cert=None, verify=True, params={
                 'command': 'listVirtualMachines',
@@ -196,7 +196,7 @@ class RequestTest(TestCase):
                 'bar[0].foo': '1000',
                 'bar[0].baz': 'blah',
                 'foo': 'foo,bar',
-                'bytes_param': 'blah'.encode('utf-8'),
+                'bytes_param': b'blah',
                 'apiKey': 'foo',
                 'signature': 'ImJ/5F0P2RDL7yn4LdLnGcEx5WE=',
             },


### PR DESCRIPTION
CloudStack requires userdata to be byte-encoded. This patch allows to pass byte-encoded userdata.