### PR TITLE
sdist: adding missing MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.py
+include LICENSE
+include tox.ini


### PR DESCRIPTION
According to [check-manifest](https://pypi.org/project/check-manifest/), it needed that file.