### PR TITLE
cli: allow extraneous keys in cloudstack.ini

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -239,4 +239,10 @@ def read_config(ini_group=None):
     except AttributeError:  # python 2
         cs_conf = dict(conf.items(ini_group))
     cs_conf['name'] = ini_group
-    return cs_conf
+
+    allowed_keys = ('endpoint', 'key', 'secret', 'timeout', 'method', 'verify',
+                    'cert', 'name', 'retry')
+
+    return dict(((k, v)
+                 for k, v in cs_conf.items()
+                 if k in allowed_keys))

--- a/tests.py
+++ b/tests.py
@@ -102,6 +102,7 @@ class ConfigTest(TestCase):
                     'endpoint = https://api.example.com/from-file\n'
                     'key = test key from file\n'
                     'secret = test secret from file\n'
+                    'theme = monokai\n'
                     'timeout = 50')
             self.addCleanup(partial(os.remove, '/tmp/cloudstack.ini'))
 


### PR DESCRIPTION
because I'm doing crazy things in _egoscale_, I'd love to be able to have extra keys into a region.

https://github.com/exoscale/egoscale/tree/less-types/cmd/cs#configuration