### PR TITLE
cli: enable themes per region

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -241,7 +241,7 @@ def read_config(ini_group=None):
     cs_conf['name'] = ini_group
 
     allowed_keys = ('endpoint', 'key', 'secret', 'timeout', 'method', 'verify',
-                    'cert', 'name', 'retry')
+                    'cert', 'name', 'retry', 'theme')
 
     return dict(((k, v)
                  for k, v in cs_conf.items()

--- a/tests.py
+++ b/tests.py
@@ -103,6 +103,7 @@ class ConfigTest(TestCase):
                     'key = test key from file\n'
                     'secret = test secret from file\n'
                     'theme = monokai\n'
+                    'other = please ignore me\n'
                     'timeout = 50')
             self.addCleanup(partial(os.remove, '/tmp/cloudstack.ini'))
 
@@ -112,6 +113,7 @@ class ConfigTest(TestCase):
                 'endpoint': 'https://api.example.com/from-file',
                 'key': 'test key from file',
                 'secret': 'test secret from file',
+                'theme': 'monokai',
                 'timeout': '50',
                 'name': 'cloudstack',
             })


### PR DESCRIPTION
for busy devOps with too many regions to manage.

```ini
[testing]
theme = native

[prod]
theme = rrt
```

![screenshot from 2018-05-18 08-26-03](https://user-images.githubusercontent.com/1388/40219361-44223032-5a75-11e8-8b33-32aa87a96cd4.png)
