### PR TITLE
tests: use pytest and simplify tox file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-cs.egg-info
 dist
-.tox
 build
+.coverage
+.eggs
+.tox
+*.egg-info
 *.pyc
+.*_cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,12 @@
 [wheel]
 universal = 1
 
+[aliases]
+test = pytest
+
+[tool:pytest]
+addopts = --cov=cs --cov-report=term-missing cs tests.py
+
 [check-manifest]
 ignore =
     tox.ini

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@ install_requires = ['pytz', 'requests']
 extras_require = {
     'highlight': ['pygments'],
 }
-tests_require = []
+tests_require = [
+    'pytest',
+    'pytest-cache',
+    'pytest-cov',
+]
 
 if sys.version_info < (3, 0):
     tests_require.append("mock")
@@ -50,10 +54,10 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ),
+    setup_requires=['pytest-runner'],
     install_requires=install_requires,
     extras_require=extras_require,
     tests_require=tests_require,
-    test_suite='tests',
     entry_points={
         'console_scripts': [
             'cs = cs:main',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{27,34,35,36,37}-test
+	py{27,34,35,36,37}
 	lint
 
 [travis]
@@ -8,8 +8,10 @@ python =
 	3.6: py36, lint
 
 [testenv]
+deps=
+	check-manifest
+	flake8
 commands =
-	test: python setup.py test
-	lint: pip install flake8 check-manifest
+	python setup.py test
+	check-manifest
 	lint: flake8 cs tests.py
-	lint: check-manifest


### PR DESCRIPTION
```
================================= test session starts ==================================
platform linux -- Python 3.7.0rc1, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
rootdir: /home/yoan/exoscale/cs, inifile: setup.cfg
plugins: cov-2.5.1, flakes-3.0.2, pep8-1.0.6
collected 11 items                                                                     

tests.py ...........                                                             [100%]

--------- coverage: platform linux, python 3.7.0-candidate-1 ---------
Name             Stmts   Miss  Cover   Missing
----------------------------------------------
cs/__init__.py      92     71    23%   10-11, 15-17, 29-30, 38-45, 49-130
cs/__main__.py       3      3     0%   1-5
cs/_async.py        77     67    13%   13-15, 18-20, 24-89, 92-113
cs/client.py       164     30    82%   10-11, 15-16, 24-27, 47, 49, 56-57, 64, 69, 79, 105, 151-158, 163-165, 181-182, 232, 234, 240-241
----------------------------------------------
TOTAL              336    171    49%


============================== 11 passed in 0.35 seconds ===============================
py37 runtests: commands[1] | check-manifest
lists of files in version control and sdist match
_______________________________________ summary ________________________________________
  py37: commands succeeded
  congratulations :)
```