### PR TITLE
improve config handling

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -43,9 +43,9 @@ ALLOWED_CONFIGS = {
     'endpoint': None,
     'key': None,
     'secret': None,
-    'timeout': 10,
+    'timeout': '10',
     'method': 'get',
-    'verify': False,
+    'verify': True,
     'cert': None,
     'name': None,
     'retry': 0,
@@ -222,10 +222,7 @@ def read_env_vars():
     env_conf = {}
     for key, default_value in ALLOWED_CONFIGS.items():
         env_key = 'CLOUDSTACK_{0}'.format(key.upper())
-        if env_key in os.environ:
-            env_conf[key] = os.environ[env_key]
-        else:
-            env_conf[key] = default_value
+        env_conf[key] = os.environ.get(env_key, default_value)
     return env_conf
 
 
@@ -260,4 +257,4 @@ def read_from_ini(ini_group):
 
     return dict(((k, v)
                  for k, v in cs_conf.items()
-                 if k in ALLOWED_CONFIGS.keys()))
+                 if k in ALLOWED_CONFIGS))

--- a/cs/client.py
+++ b/cs/client.py
@@ -249,16 +249,13 @@ def read_from_ini(ini_group):
     if 'CLOUDSTACK_CONFIG' in os.environ:
         paths += (os.path.expanduser(os.environ['CLOUDSTACK_CONFIG']),)
 
-    if not any([os.path.exists(c) for c in paths]):
-        raise SystemExit("Config file not found. Tried {0}".format(
-            ", ".join(paths)))
-
     conf = ConfigParser()
     conf.read(paths)
-    try:
-        cs_conf = conf[ini_group]
-    except AttributeError:  # python 2
-        cs_conf = dict(conf.items(ini_group))
+
+    if not conf.has_section(ini_group):
+        return dict()
+
+    cs_conf = dict(conf.items(ini_group))
     cs_conf['name'] = ini_group
 
     return dict(((k, v)

--- a/tests.py
+++ b/tests.py
@@ -73,6 +73,7 @@ class ConfigTest(TestCase):
                 'cert': None,
                 'name': None,
                 'retry': 0,
+                'theme': None,
             })
 
         with env(CLOUDSTACK_KEY='test key from env',
@@ -94,6 +95,37 @@ class ConfigTest(TestCase):
                 'cert': '/path/to/cert.pem',
                 'name': None,
                 'retry': '5',
+                'theme': None,
+            })
+
+    def test_env_var_combined_with_dir_config(self):
+        # Secret is missing in ini file
+        with open('/tmp/cloudstack.ini', 'w') as f:
+            f.write('[hanibal]\n'
+                    'endpoint = https://api.example.com/from-file\n'
+                    'key = test key from file\n'
+                    'theme = monokai\n'
+                    'other = please ignore me\n'
+                    'timeout = 50')
+            self.addCleanup(partial(os.remove, '/tmp/cloudstack.ini'))
+
+        # Secret gets read from env var
+        with env(CLOUDSTACK_ENDPOINT='https://api.example.com/from-env',
+                 CLOUDSTACK_SECRET='test secret from env',
+                 CLOUDSTACK_REGION='hanibal',
+                 CLOUDSTACK_KEY='test key from env'), cwd('/tmp'):
+            conf = read_config()
+            self.assertEqual(dict(conf), {
+                'endpoint': 'https://api.example.com/from-file',
+                'key': 'test key from file',
+                'secret': 'test secret from env',
+                'theme': 'monokai',
+                'timeout': '50',
+                'name': 'hanibal',
+                'verify': True,
+                'retry': 0,
+                'method': 'get',
+                'cert': None,
             })
 
     def test_current_dir_config(self):
@@ -116,6 +148,10 @@ class ConfigTest(TestCase):
                 'theme': 'monokai',
                 'timeout': '50',
                 'name': 'cloudstack',
+                'verify': True,
+                'retry': 0,
+                'method': 'get',
+                'cert': None,
             })
 
 

--- a/tests.py
+++ b/tests.py
@@ -112,11 +112,10 @@ class ConfigTest(TestCase):
         # Secret gets read from env var
         with env(CLOUDSTACK_ENDPOINT='https://api.example.com/from-env',
                  CLOUDSTACK_SECRET='test secret from env',
-                 CLOUDSTACK_REGION='hanibal',
-                 CLOUDSTACK_KEY='test key from env'), cwd('/tmp'):
+                 CLOUDSTACK_REGION='hanibal'), cwd('/tmp'):
             conf = read_config()
             self.assertEqual(dict(conf), {
-                'endpoint': 'https://api.example.com/from-file',
+                'endpoint': 'https://api.example.com/from-env',
                 'key': 'test key from file',
                 'secret': 'test secret from env',
                 'theme': 'monokai',


### PR DESCRIPTION
Allows to default by using one or more env vars and fill up the rest with a partial ini config file:

~~~
export CLOUDSTACK_SECRET=...
~~~

a ini file without a secret
~~~
$ cat ~/.cloudstack.ini
[cloudstack]
endpoint = https://api.exoscale.ch/compute
key = cloudstack api key
~~~

Could be helpful in environments in which you don't want to store the secrets in a file.