### PR TITLE
client: enforce signatureVersion=3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,10 @@ seconds). The default value is 10.
 (integer) can be used to retry ``list`` and ``queryAsync`` requests on
 failure. The default value is 0, meaning no retry.
 
+``CLOUDSTACK_EXPIRATION`` or the ``expiration`` entry in the configuration file
+(integer) can be used to set how long a signature is valid. By default, it picks
+10 minutes but may be deactivated using any negative value, e.g. -1.
+
 Multiple credentials can be set in ``.cloudstack.ini``. This allows selecting
 the credentials or endpoint to use with a command-line flag.
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup
 with open('README.rst', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['requests']
+install_requires = ['pytz', 'requests']
 extras_require = {
     'highlight': ['pygments'],
 }


### PR DESCRIPTION
To deactivate it, set the expiration to a negative value. Otherwise it does a "safe" 10 minutes and let you configure it like the others. A negative value deactivates the v3 version.

http://docs.cloudstack.apache.org/en/4.11.1.0/developersguide/dev.html?enabling-api-call-expiration

New dependency: [`pytz`](https://pypi.org/project/pytz/)

cf. https://github.com/exoscale/egoscale/pull/304