### PR TITLE
async: fetch_list=True to return a list

### DIFF
--- a/cs/_async.py
+++ b/cs/_async.py
@@ -72,7 +72,7 @@ class AIOCloudStack(CloudStack):
                     else:
                         final_data.extend(data[key])
                         page += 1
-                if fetch_result and 'jobid' in data:
+                elif fetch_result and 'jobid' in data:
                     try:
                         final_data = await asyncio.wait_for(
                             self._jobresult(data['jobid']),


### PR DESCRIPTION
**What I did**

```python
await cs.listVirtualMachines(fetch_list=True)
```

**What happened**

```json
{
  "count": 10,
  "virtualmachine": [{...}]
}
```

**What was expected**

```json
[{...}]
```