### PR TITLE
client: allow to mix cloudstack.ini and environ

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,11 @@ Usage::
 
 Optionally ``CLOUDSTACK_REGION`` can be used to overwrite the default region ``cloudstack``.
 
+For the power users that don't want to put any secrets on disk,
+``CLOUDSTACK_OVERRIDES`` let you pick which key will be set from the
+environment even if present in the ini file.
+
+
 Pagination
 ----------
 

--- a/cs/client.py
+++ b/cs/client.py
@@ -302,5 +302,5 @@ def read_config(ini_group=None):
     if None in (config.get(k) for k in REQUIRED_CONFIG_KEYS):
         missings = (k for k in REQUIRED_CONFIG_KEYS if not config.get(k))
         raise ValueError("the configuration is missing the following keys: "
-                          ", ".join(missings))
+                         ", ".join(missings))
     return config

--- a/cs/client.py
+++ b/cs/client.py
@@ -300,7 +300,7 @@ def read_config(ini_group=None):
                   **{k: v for k, v in env_conf.items() if k in overrides})
 
     if None in (config.get(k) for k in REQUIRED_CONFIG_KEYS):
-        missings = REQUIRED_CONFIG_KEYS.difference(config)
+        missings = (k for k in REQUIRED_CONFIG_KEYS if not config.get(k))
         raise ValueError("the configuration is missing the following keys: "
                          ", ".join(missings))
     return config

--- a/cs/client.py
+++ b/cs/client.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import os
 import sys
+import re
 from datetime import datetime, timedelta
 
 try:
@@ -41,6 +42,18 @@ if sys.version_info >= (3, 5):
 
 PAGE_SIZE = 500
 EXPIRES_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+REQUIRED_CONFIG_KEYS = "endpoint", "key", "secret", "method", "timeout"
+ALLOWED_CONFIG_KEYS = "verify", "cert", "retry", "theme", "expiration"
+DEFAULT_CONFIG = {
+    "timeout": 10,
+    "method": "get",
+    "retry": 0,
+    "verify": True,
+    "cert": None,
+    "name": None,
+    "expiration": 600,
+}
 
 
 def cs_encode(s):
@@ -231,27 +244,7 @@ class CloudStack(object):
         return base64.b64encode(digest).decode('utf-8').strip()
 
 
-def read_config(ini_group=None):
-    if not ini_group:
-        ini_group = os.environ.get('CLOUDSTACK_REGION', 'cloudstack')
-    # Try env vars first
-    os.environ.setdefault('CLOUDSTACK_METHOD', 'get')
-    os.environ.setdefault('CLOUDSTACK_TIMEOUT', '10')
-    os.environ.setdefault('CLOUDSTACK_EXPIRATION', '600')
-    keys = ['endpoint', 'key', 'secret', 'method', 'timeout', 'expiration']
-    env_conf = {}
-    for key in keys:
-        if 'CLOUDSTACK_{0}'.format(key.upper()) not in os.environ:
-            break
-        else:
-            env_conf[key] = os.environ['CLOUDSTACK_{0}'.format(key.upper())]
-    else:
-        env_conf['verify'] = os.environ.get('CLOUDSTACK_VERIFY', True)
-        env_conf['cert'] = os.environ.get('CLOUDSTACK_CERT', None)
-        env_conf['name'] = None
-        env_conf['retry'] = os.environ.get('CLOUDSTACK_RETRY', 0)
-        return env_conf
-
+def read_config_from_ini(ini_group=None):
     # Config file: $PWD/cloudstack.ini or $HOME/.cloudstack.ini
     # Last read wins in configparser
     paths = (
@@ -266,15 +259,48 @@ def read_config(ini_group=None):
             ", ".join(paths)))
     conf = ConfigParser()
     conf.read(paths)
-    try:
-        cs_conf = conf[ini_group]
-    except AttributeError:  # python 2
-        cs_conf = dict(conf.items(ini_group))
-    cs_conf['name'] = ini_group
 
-    allowed_keys = ('endpoint', 'key', 'secret', 'timeout', 'method', 'verify',
-                    'cert', 'name', 'retry', 'theme', 'expiration')
+    if not ini_group:
+        ini_group = os.getenv('CLOUDSTACK_REGION', 'cloudstack')
 
-    return dict(((k, v)
-                 for k, v in cs_conf.items()
-                 if k in allowed_keys))
+    if not conf.has_section(ini_group):
+        return dict(name=None)
+
+    ini_config = {k: v
+                  for k, v in conf.items(ini_group)
+                  if k in REQUIRED_CONFIG_KEYS + ALLOWED_CONFIG_KEYS}
+    ini_config["name"] = ini_group
+    return ini_config
+
+
+def read_config(ini_group=None):
+    """
+    Read the configuration from the environment, or config.
+
+    First it try to go for the environment, then it overrides
+    those with the cloudstack.ini file.
+    """
+    env_conf = dict(DEFAULT_CONFIG)
+    for key in REQUIRED_CONFIG_KEYS + ALLOWED_CONFIG_KEYS:
+        env_key = "CLOUDSTACK_{0}".format(key.upper())
+        value = os.getenv(env_key)
+        if value:
+            env_conf[key] = value
+
+    # overrides means we have a .ini to read
+    overrides = os.getenv('CLOUDSTACK_OVERRIDES', '').strip()
+
+    if not overrides and all(k in env_conf for k in REQUIRED_CONFIG_KEYS):
+        return env_conf
+
+    ini_conf = read_config_from_ini(ini_group)
+
+    overrides = [s.lower() for s in re.split(r'\W+', overrides)]
+    config = dict(dict(env_conf, **ini_conf),
+                  **{k: v for k, v in env_conf.items() if k in overrides})
+
+    if None in (config.get(k) for k in REQUIRED_CONFIG_KEYS):
+        missings = (k for k in REQUIRED_CONFIG_KEYS if not config.get(k))
+        raise ValueError("the configuration is missing the following keys: "
+                          ", ".join(missings))
+    return config

--- a/cs/client.py
+++ b/cs/client.py
@@ -266,9 +266,10 @@ def read_config_from_ini(ini_group=None):
     if not conf.has_section(ini_group):
         return dict(name=None)
 
+    all_keys = REQUIRED_CONFIG_KEYS.union(ALLOWED_CONFIG_KEYS)
     ini_config = {k: v
                   for k, v in conf.items(ini_group)
-                  if k in REQUIRED_CONFIG_KEYS.union(ALLOWED_CONFIG_KEYS)}
+                  if v and k in all_keys}
     ini_config["name"] = ini_group
     return ini_config
 
@@ -299,8 +300,8 @@ def read_config(ini_group=None):
     config = dict(dict(env_conf, **ini_conf),
                   **{k: v for k, v in env_conf.items() if k in overrides})
 
-    if None in (config.get(k) for k in REQUIRED_CONFIG_KEYS):
-        missings = (k for k in REQUIRED_CONFIG_KEYS if not config.get(k))
+    missings = REQUIRED_CONFIG_KEYS.difference(config)
+    if missings:
         raise ValueError("the configuration is missing the following keys: "
                          ", ".join(missings))
     return config

--- a/tests.py
+++ b/tests.py
@@ -118,7 +118,7 @@ class ConfigTest(TestCase):
                  CLOUDSTACK_REGION='hanibal',
                  CLOUDSTACK_OVERRIDES='endpoint,secret'), cwd('/tmp'):
             conf = read_config()
-            self.assertEqual(dict(conf), {
+            self.assertEqual(conf, {
                 'endpoint': 'https://api.example.com/from-env',
                 'key': 'test key from file',
                 'secret': 'test secret from env',
@@ -145,7 +145,7 @@ class ConfigTest(TestCase):
 
         with cwd('/tmp'):
             conf = read_config()
-            self.assertEqual(dict(conf), {
+            self.assertEqual(conf, {
                 'endpoint': 'https://api.example.com/from-file',
                 'key': 'test key from file',
                 'secret': 'test secret from file',

--- a/tests.py
+++ b/tests.py
@@ -40,7 +40,8 @@ def cwd(path):
     initial = os.getcwd()
     os.chdir(path)
     try:
-        yield
+        with patch('os.path.expanduser', new=lambda x: path):
+            yield
     finally:
         os.chdir(initial)
 
@@ -69,9 +70,9 @@ class ConfigTest(TestCase):
                 'key': 'test key from env',
                 'secret': 'test secret from env',
                 'endpoint': 'https://api.example.com/from-env',
-                'expiration': '600',
+                'expiration': 600,
                 'method': 'get',
-                'timeout': '10',
+                'timeout': 10,
                 'verify': True,
                 'cert': None,
                 'name': None,
@@ -91,13 +92,44 @@ class ConfigTest(TestCase):
                 'key': 'test key from env',
                 'secret': 'test secret from env',
                 'endpoint': 'https://api.example.com/from-env',
-                'expiration': '600',
+                'expiration': 600,
                 'method': 'post',
                 'timeout': '99',
                 'verify': '/path/to/ca.pem',
                 'cert': '/path/to/cert.pem',
                 'name': None,
                 'retry': '5',
+            })
+
+    def test_env_var_combined_with_dir_config(self):
+        with open('/tmp/cloudstack.ini', 'w') as f:
+            f.write('[hanibal]\n'
+                    'endpoint = https://api.example.com/from-file\n'
+                    'key = test key from file\n'
+                    'secret = secret from file\n'
+                    'theme = monokai\n'
+                    'other = please ignore me\n'
+                    'timeout = 50')
+            self.addCleanup(partial(os.remove, '/tmp/cloudstack.ini'))
+        # Secret gets read from env var
+        with env(CLOUDSTACK_ENDPOINT='https://api.example.com/from-env',
+                 CLOUDSTACK_KEY='test key from env',
+                 CLOUDSTACK_SECRET='test secret from env',
+                 CLOUDSTACK_REGION='hanibal',
+                 CLOUDSTACK_OVERRIDES='endpoint,secret'), cwd('/tmp'):
+            conf = read_config()
+            self.assertEqual(dict(conf), {
+                'endpoint': 'https://api.example.com/from-env',
+                'key': 'test key from file',
+                'secret': 'test secret from env',
+                'expiration': 600,
+                'theme': 'monokai',
+                'timeout': '50',
+                'name': 'hanibal',
+                'verify': True,
+                'retry': 0,
+                'method': 'get',
+                'cert': None,
             })
 
     def test_current_dir_config(self):
@@ -117,10 +149,28 @@ class ConfigTest(TestCase):
                 'endpoint': 'https://api.example.com/from-file',
                 'key': 'test key from file',
                 'secret': 'test secret from file',
+                'expiration': 600,
                 'theme': 'monokai',
                 'timeout': '50',
                 'name': 'cloudstack',
+                'verify': True,
+                'retry': 0,
+                'method': 'get',
+                'cert': None,
             })
+
+    def test_incomplete_config(self):
+        with open('/tmp/cloudstack.ini', 'w') as f:
+            f.write('[hanibal]\n'
+                    'endpoint = https://api.example.com/from-file\n'
+                    'secret = secret from file\n'
+                    'theme = monokai\n'
+                    'other = please ignore me\n'
+                    'timeout = 50')
+            self.addCleanup(partial(os.remove, '/tmp/cloudstack.ini'))
+        # Secret gets read from env var
+        with cwd('/tmp'):
+            self.assertRaises(ValueError, read_config)
 
 
 class RequestTest(TestCase):


### PR DESCRIPTION
Using `CLOUDSTACK_OVERRIDES`, you can mix the `cloudstack.ini` and
the env. As the default behaviour favors the config file over
the environment. The value is a separated list of names such
as the one found in the ini.

Build upon the previous work done by @resmo, #68 