### PR TITLE
client: add trace option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,16 @@ Or in Python::
 
     cs.listVirtualMachines(fetch_list=True)
 
+Tracing HTTP requests
+---------------------
+
+Once in a while, it could be useful to understand, see what HTTP calls are made
+under the hood. The ``trace`` flag (or ``CLOUDSTACK_TRACE``) does just that::
+
+   $ cs --trace listVirtualMachines
+
+   $ cs -t listZones
+
 Async client
 ------------
 

--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -47,7 +47,7 @@ def _format_json(data, theme):
 
 def main():
     parser = argparse.ArgumentParser(description='Cloustack client.')
-    parser.add_argument('--region', metavar='REGION',
+    parser.add_argument('--region', '-r', metavar='REGION',
                         help='Cloudstack region in ~/.cloudstack.ini',
                         default=os.environ.get('CLOUDSTACK_REGION',
                                                'cloudstack'))
@@ -61,6 +61,9 @@ def main():
                         help='do not wait for async result')
     parser.add_argument('--quiet', '-q', action='store_true', default=False,
                         help='do not display additional status messages')
+    parser.add_argument('--trace', '-t', action='store_true',
+                        default=os.environ.get('CLOUDSTACK_TRACE', False),
+                        help='trace the HTTP requests done on stderr')
     parser.add_argument('command', metavar="COMMAND",
                         help='Cloudstack API command to execute')
 
@@ -90,6 +93,8 @@ def main():
 
     if options.post:
         config['method'] = 'post'
+    if options.trace:
+        config['trace'] = True
     cs = CloudStack(**config)
     ok = True
     try:

--- a/tests.py
+++ b/tests.py
@@ -193,7 +193,7 @@ class RequestTest(TestCase):
                                           headers={'Accept-Encoding': 'br'})
         self.assertEqual(machines, {})
 
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], kwargs = mock.call_args
 
@@ -221,7 +221,7 @@ class RequestTest(TestCase):
                                           fetch_list=True)
         self.assertEqual(machines, [])
 
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], kwargs = mock.call_args
 
@@ -246,7 +246,7 @@ class RequestTest(TestCase):
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(listall=1, unicode_param=u'éèààû')
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], _ = mock.call_args
 
@@ -268,7 +268,7 @@ class RequestTest(TestCase):
         cs.listVirtualMachines(foo=["foo", "bar"],
                                bar=[{'baz': 'blah', 'foo': 1000}],
                                bytes_param=b'blah')
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], kwargs = mock.call_args
 
@@ -296,7 +296,7 @@ class RequestTest(TestCase):
         }
         cs.scaleVirtualMachine(id='a',
                                details={'cpunumber': 1000, 'memory': '640k'})
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], kwargs = mock.call_args
 
@@ -321,7 +321,7 @@ class RequestTest(TestCase):
             'createnetworkresponse': {},
         }
         cs.createNetwork(name="", display_text="")
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], kwargs = mock.call_args
 
@@ -346,7 +346,7 @@ class RequestTest(TestCase):
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(blah='brah')
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], kwargs = mock.call_args
 
@@ -381,7 +381,7 @@ class RequestTest(TestCase):
             'createnetworkresponse': {},
         }
         cs.createNetwork(name="", display_text="")
-        mock.assert_called_once()
+        self.assertEqual(1, mock.call_count)
 
         [request], _ = mock.call_args
 

--- a/tests.py
+++ b/tests.py
@@ -223,8 +223,7 @@ class RequestTest(TestCase):
 
         mock.assert_called_once()
 
-        args, kwargs = mock.call_args
-        [request] = args
+        [request], kwargs = mock.call_args
 
         self.assertEqual(dict(cert=None, timeout=20, verify=True), kwargs)
         self.assertEqual('GET', request.method)
@@ -249,8 +248,7 @@ class RequestTest(TestCase):
         cs.listVirtualMachines(listall=1, unicode_param=u'éèààû')
         mock.assert_called_once()
 
-        args, _ = mock.call_args
-        [request] = args
+        [request], _ = mock.call_args
 
         url = urlparse(request.url)
         qs = parse_qs(url.query, True)
@@ -272,8 +270,7 @@ class RequestTest(TestCase):
                                bytes_param=b'blah')
         mock.assert_called_once()
 
-        args, kwargs = mock.call_args
-        [request] = args
+        [request], kwargs = mock.call_args
 
         self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
         self.assertEqual('GET', request.method)
@@ -301,8 +298,7 @@ class RequestTest(TestCase):
                                details={'cpunumber': 1000, 'memory': '640k'})
         mock.assert_called_once()
 
-        args, kwargs = mock.call_args
-        [request] = args
+        [request], kwargs = mock.call_args
 
         self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
         self.assertEqual('GET', request.method)
@@ -327,8 +323,7 @@ class RequestTest(TestCase):
         cs.createNetwork(name="", display_text="")
         mock.assert_called_once()
 
-        args, kwargs = mock.call_args
-        [request] = args
+        [request], kwargs = mock.call_args
 
         self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
         self.assertEqual('GET', request.method)
@@ -353,8 +348,7 @@ class RequestTest(TestCase):
         cs.listVirtualMachines(blah='brah')
         mock.assert_called_once()
 
-        args, kwargs = mock.call_args
-        [request] = args
+        [request], kwargs = mock.call_args
 
         self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
         self.assertEqual('POST', request.method)
@@ -389,8 +383,7 @@ class RequestTest(TestCase):
         cs.createNetwork(name="", display_text="")
         mock.assert_called_once()
 
-        args, _ = mock.call_args
-        [request] = args
+        [request], _ = mock.call_args
 
         url = urlparse(request.url)
         qs = parse_qs(url.query, True)

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-from __future__ import unicode_literals
-
 import os
 import sys
 import datetime
@@ -10,9 +8,14 @@ from functools import partial
 from unittest import TestCase
 
 try:
-    from unittest.mock import patch, call
+    from unittest.mock import patch
 except ImportError:
-    from mock import patch, call
+    from mock import patch
+
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
 
 from cs import CloudStack, CloudStackException, read_config
 from cs.client import EXPIRES_FORMAT
@@ -66,18 +69,19 @@ class ConfigTest(TestCase):
                  CLOUDSTACK_SECRET='test secret from env',
                  CLOUDSTACK_ENDPOINT='https://api.example.com/from-env'):
             conf = read_config()
-            self.assertEqual(conf, {
+            self.assertEqual({
                 'key': 'test key from env',
                 'secret': 'test secret from env',
                 'endpoint': 'https://api.example.com/from-env',
                 'expiration': 600,
                 'method': 'get',
                 'timeout': 10,
+                'trace': None,
                 'verify': True,
                 'cert': None,
                 'name': None,
                 'retry': 0,
-            })
+            }, conf)
 
         with env(CLOUDSTACK_KEY='test key from env',
                  CLOUDSTACK_SECRET='test secret from env',
@@ -88,18 +92,19 @@ class ConfigTest(TestCase):
                  CLOUDSTACK_VERIFY='/path/to/ca.pem',
                  CLOUDSTACK_CERT='/path/to/cert.pem'):
             conf = read_config()
-            self.assertEqual(conf, {
+            self.assertEqual({
                 'key': 'test key from env',
                 'secret': 'test secret from env',
                 'endpoint': 'https://api.example.com/from-env',
                 'expiration': 600,
                 'method': 'post',
                 'timeout': '99',
+                'trace': None,
                 'verify': '/path/to/ca.pem',
                 'cert': '/path/to/cert.pem',
                 'name': None,
                 'retry': '5',
-            })
+            }, conf)
 
     def test_env_var_combined_with_dir_config(self):
         with open('/tmp/cloudstack.ini', 'w') as f:
@@ -118,19 +123,20 @@ class ConfigTest(TestCase):
                  CLOUDSTACK_REGION='hanibal',
                  CLOUDSTACK_OVERRIDES='endpoint,secret'), cwd('/tmp'):
             conf = read_config()
-            self.assertEqual(conf, {
+            self.assertEqual({
                 'endpoint': 'https://api.example.com/from-env',
                 'key': 'test key from file',
                 'secret': 'test secret from env',
                 'expiration': 600,
                 'theme': 'monokai',
                 'timeout': '50',
+                'trace': None,
                 'name': 'hanibal',
                 'verify': True,
                 'retry': 0,
                 'method': 'get',
                 'cert': None,
-            })
+            }, conf)
 
     def test_current_dir_config(self):
         with open('/tmp/cloudstack.ini', 'w') as f:
@@ -145,19 +151,20 @@ class ConfigTest(TestCase):
 
         with cwd('/tmp'):
             conf = read_config()
-            self.assertEqual(conf, {
+            self.assertEqual({
                 'endpoint': 'https://api.example.com/from-file',
                 'key': 'test key from file',
                 'secret': 'test secret from file',
                 'expiration': 600,
                 'theme': 'monokai',
                 'timeout': '50',
+                'trace': None,
                 'name': 'cloudstack',
                 'verify': True,
                 'retry': 0,
                 'method': 'get',
                 'cert': None,
-            })
+            }, conf)
 
     def test_incomplete_config(self):
         with open('/tmp/cloudstack.ini', 'w') as f:
@@ -174,198 +181,226 @@ class ConfigTest(TestCase):
 
 
 class RequestTest(TestCase):
-    @patch('requests.get')
-    def test_request_params(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+    @patch("requests.Session.send")
+    def test_request_params(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         timeout=20, expiration=-1)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'listvirtualmachinesresponse': {},
         }
         machines = cs.listVirtualMachines(listall='true',
                                           headers={'Accept-Encoding': 'br'})
         self.assertEqual(machines, {})
-        get.assert_called_once_with(
-            'localhost', timeout=20, verify=True, cert=None,
-            headers={
-                'Accept-Encoding': 'br',
-            },
-            params={
-                'apiKey': 'foo',
-                'response': 'json',
-                'command': 'listVirtualMachines',
-                'listall': 'true',
-                'signature': 'B0d6hBsZTcFVCiioSxzwKA9Pke8=',
-            },
-        )
 
-    @patch('requests.get')
-    def test_request_params_casing(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+        mock.assert_called_once()
+
+        [request], kwargs = mock.call_args
+
+        self.assertEqual(dict(cert=None, timeout=20, verify=True), kwargs)
+        self.assertEqual('GET', request.method)
+        self.assertEqual('br', request.headers['Accept-Encoding'])
+
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('listVirtualMachines', qs['command'][0])
+        self.assertEqual('B0d6hBsZTcFVCiioSxzwKA9Pke8=', qs['signature'][0])
+        self.assertEqual('true', qs['listall'][0])
+
+    @patch("requests.Session.send")
+    def test_request_params_casing(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         timeout=20, expiration=-1)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'listvirtualmachinesresponse': {},
         }
         machines = cs.listVirtualMachines(zoneId=2, templateId='3',
                                           temPlateidd='4', pageSize='10',
                                           fetch_list=True)
         self.assertEqual(machines, [])
-        get.assert_called_once_with(
-            'localhost', timeout=20, verify=True, cert=None, headers=None,
-            params={
-                'apiKey': 'foo',
-                'response': 'json',
-                'command': 'listVirtualMachines',
-                'signature': 'mMS7XALuGkCXk7kj5SywySku0Z0=',
-                'templateId': '3',
-                'temPlateidd': '4',
-                'zoneId': '2',
-                'page': '1',
-                'pageSize': '10',
-            },
-        )
 
-    @patch('requests.get')
-    def test_encoding(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+        mock.assert_called_once()
+
+        args, kwargs = mock.call_args
+        [request] = args
+
+        self.assertEqual(dict(cert=None, timeout=20, verify=True), kwargs)
+        self.assertEqual('GET', request.method)
+        self.assertFalse(request.headers)
+
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('listVirtualMachines', qs['command'][0])
+        self.assertEqual('mMS7XALuGkCXk7kj5SywySku0Z0=', qs['signature'][0])
+        self.assertEqual('3', qs['templateId'][0])
+        self.assertEqual('4', qs['temPlateidd'][0])
+
+    @patch("requests.Session.send")
+    def test_encoding(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         expiration=-1)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(listall=1, unicode_param=u'éèààû')
-        get.assert_called_once_with(
-            'localhost', timeout=10, verify=True, cert=None, headers=None,
-            params={
-                'apiKey': 'foo',
-                'response': 'json',
-                'command': 'listVirtualMachines',
-                'listall': '1',
-                'unicode_param': u'éèààû',
-                'signature': 'gABU/KFJKD3FLAgKDuxQoryu4sA=',
-            },
-        )
+        mock.assert_called_once()
 
-    @patch("requests.get")
-    def test_transform(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+        args, _ = mock.call_args
+        [request] = args
+
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('listVirtualMachines', qs['command'][0])
+        self.assertEqual('gABU/KFJKD3FLAgKDuxQoryu4sA=', qs['signature'][0])
+        self.assertEqual('éèààû', qs['unicode_param'][0])
+
+    @patch("requests.Session.send")
+    def test_transform(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         expiration=-1)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(foo=["foo", "bar"],
                                bar=[{'baz': 'blah', 'foo': 1000}],
                                bytes_param=b'blah')
-        get.assert_called_once_with(
-            'localhost', timeout=10, cert=None, verify=True, headers=None,
-            params={
-                'command': 'listVirtualMachines',
-                'response': 'json',
-                'bar[0].foo': '1000',
-                'bar[0].baz': 'blah',
-                'foo': 'foo,bar',
-                'bytes_param': b'blah',
-                'apiKey': 'foo',
-                'signature': 'ImJ/5F0P2RDL7yn4LdLnGcEx5WE=',
-            },
-        )
+        mock.assert_called_once()
 
-    @patch("requests.get")
-    def test_transform_dict(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+        args, kwargs = mock.call_args
+        [request] = args
+
+        self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
+        self.assertEqual('GET', request.method)
+        self.assertFalse(request.headers)
+
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('listVirtualMachines', qs['command'][0])
+        self.assertEqual('ImJ/5F0P2RDL7yn4LdLnGcEx5WE=', qs['signature'][0])
+        self.assertEqual('1000', qs['bar[0].foo'][0])
+        self.assertEqual('blah', qs['bar[0].baz'][0])
+        self.assertEqual('blah', qs['bytes_param'][0])
+        self.assertEqual('foo,bar', qs['foo'][0])
+
+    @patch("requests.Session.send")
+    def test_transform_dict(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         expiration=-1)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'scalevirtualmachineresponse': {},
         }
         cs.scaleVirtualMachine(id='a',
                                details={'cpunumber': 1000, 'memory': '640k'})
-        get.assert_called_once_with(
-            'localhost', timeout=10, cert=None, verify=True, headers=None,
-            params={
-                'command': 'scaleVirtualMachine',
-                'response': 'json',
-                'id': 'a',
-                'details[0].cpunumber': '1000',
-                'details[0].memory': '640k',
-                'apiKey': 'foo',
-                'signature': 'ZNl66z3gFhnsx2Eo3vvCIM0kAgI=',
-            },
-        )
+        mock.assert_called_once()
 
-    @patch("requests.get")
-    def test_transform_empty(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+        args, kwargs = mock.call_args
+        [request] = args
+
+        self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
+        self.assertEqual('GET', request.method)
+        self.assertFalse(request.headers)
+
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('scaleVirtualMachine', qs['command'][0])
+        self.assertEqual('ZNl66z3gFhnsx2Eo3vvCIM0kAgI=', qs['signature'][0])
+        self.assertEqual('1000', qs['details[0].cpunumber'][0])
+        self.assertEqual('640k', qs['details[0].memory'][0])
+
+    @patch("requests.Session.send")
+    def test_transform_empty(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         expiration=-1)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'createnetworkresponse': {},
         }
         cs.createNetwork(name="", display_text="")
-        get.assert_called_once_with(
-            'localhost', timeout=10, cert=None, verify=True, headers=None,
-            params={
-                'command': 'createNetwork',
-                'response': 'json',
-                'name': '',
-                'display_text': '',
-                'apiKey': 'foo',
-                'signature': 'CistTEiPt/4Rv1v4qSyILvPbhmg=',
-            },
-        )
+        mock.assert_called_once()
 
-    @patch("requests.post")
-    @patch("requests.get")
-    def test_method(self, get, post):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+        args, kwargs = mock.call_args
+        [request] = args
+
+        self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
+        self.assertEqual('GET', request.method)
+        self.assertFalse(request.headers)
+
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('createNetwork', qs['command'][0])
+        self.assertEqual('CistTEiPt/4Rv1v4qSyILvPbhmg=', qs['signature'][0])
+        self.assertEqual('', qs['name'][0])
+        self.assertEqual('', qs['display_text'][0])
+
+    @patch("requests.Session.send")
+    def test_method(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         method='post', expiration=-1)
-        post.return_value.status_code = 200
-        post.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'listvirtualmachinesresponse': {},
         }
         cs.listVirtualMachines(blah='brah')
-        self.assertEqual(get.call_args_list, [])
-        self.assertEqual(post.call_args_list, [
-            call(
-                'localhost', timeout=10, verify=True, cert=None, headers=None,
-                data={
-                   'command': 'listVirtualMachines',
-                   'blah': 'brah',
-                   'apiKey': 'foo',
-                   'response': 'json',
-                   'signature': '58VvLSaVUqHnG9DhXNOAiDFwBoA=',
-                }
-            )]
-        )
+        mock.assert_called_once()
 
-    @patch("requests.get")
-    def test_error(self, get):
-        get.return_value.status_code = 530
-        get.return_value.json.return_value = {
+        args, kwargs = mock.call_args
+        [request] = args
+
+        self.assertEqual(dict(cert=None, timeout=10, verify=True), kwargs)
+        self.assertEqual('POST', request.method)
+        self.assertEqual('application/x-www-form-urlencoded',
+                         request.headers['Content-Type'])
+
+        qs = parse_qs(request.body, True)
+
+        self.assertEqual('listVirtualMachines', qs['command'][0])
+        self.assertEqual('58VvLSaVUqHnG9DhXNOAiDFwBoA=', qs['signature'][0])
+        self.assertEqual('brah', qs['blah'][0])
+
+    @patch("requests.Session.send")
+    def test_error(self, mock):
+        mock.return_value.status_code = 530
+        mock.return_value.json.return_value = {
             'listvirtualmachinesresponse': {'errorcode': 530,
                                             'uuidList': [],
                                             'cserrorcode': 9999,
                                             'errortext': 'Fail'}}
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar')
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar')
         self.assertRaises(CloudStackException, cs.listVirtualMachines)
 
-    @patch("requests.get")
-    def test_signature_v3(self, get):
-        cs = CloudStack(endpoint='localhost', key='foo', secret='bar',
+    @patch("requests.Session.send")
+    def test_signature_v3(self, mock):
+        cs = CloudStack(endpoint='https://localhost', key='foo', secret='bar',
                         expiration=600)
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {
+        mock.return_value.status_code = 200
+        mock.return_value.json.return_value = {
             'createnetworkresponse': {},
         }
         cs.createNetwork(name="", display_text="")
+        mock.assert_called_once()
 
-        _, kwargs = get.call_args
-        params = kwargs['params']
-        assert '3' == params['signatureVersion'], kwargs
+        args, _ = mock.call_args
+        [request] = args
 
+        url = urlparse(request.url)
+        qs = parse_qs(url.query, True)
+
+        self.assertEqual('createNetwork', qs['command'][0])
+        self.assertEqual('3', qs['signatureVersion'][0])
+
+        expires = qs['expires'][0]
         # we ignore the timezone for Python2's lack of %z
-        expires = datetime.datetime.strptime(params['expires'][:19],
+        expires = datetime.datetime.strptime(expires[:19],
                                              EXPIRES_FORMAT[:-2])
-        assert expires > datetime.datetime.utcnow(), params['expires']
+
+        self.assertTrue(expires > datetime.datetime.utcnow(), expires)


### PR DESCRIPTION
```console
> cs --trace listZones > /dev/null     
GET https://api.exoscale.com/compute?apiKey=EXOc94bc655ff901b7218a5c3cd&command=listZones&response=json&signatureVersion=3&expires=2018-11-12T13%3A47%3A39%2B0000&signature=<< sig >>

200 OK
Date: Mon, 12 Nov 2018 13:37:19 GMT
Content-Type: application/json;charset=utf-8
Content-Length: 1104
Connection: close
Vary: Accept-Encoding, Accept-Encoding, User-Agent
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-XSS-Protection: 1; mode=block
X-Request-Id: 57c51ef5-bee4-48c1-865e-d39af14f55dd 

<< body >>
```