### PR TITLE
config: accept verify=False

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,10 @@ failure. The default value is 0, meaning no retry.
 (integer) can be used to set how long a signature is valid. By default, it picks
 10 minutes but may be deactivated using any negative value, e.g. -1.
 
+``CLOUDSTACK_DANGEROUS_NO_TLS_VERIFY`` or the ``dangerous_no_tls_verify`` entry
+in the configuration file (boolean) can be used to deactivate the TLS verification
+made when using the HTTPS protocol.
+
 Multiple credentials can be set in ``.cloudstack.ini``. This allows selecting
 the credentials or endpoint to use with a command-line flag.
 

--- a/cs/client.py
+++ b/cs/client.py
@@ -142,7 +142,7 @@ class CloudStack(object):
         self.secret = secret
         self.timeout = int(timeout)
         self.method = method.lower()
-        if verify is not None:
+        if verify:
             self.verify = verify
         else:
             self.verify = not dangerous_no_tls_verify

--- a/cs/client.py
+++ b/cs/client.py
@@ -53,17 +53,18 @@ EXPIRES_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
 REQUIRED_CONFIG_KEYS = {"endpoint", "key", "secret", "method", "timeout"}
 ALLOWED_CONFIG_KEYS = {"verify", "cert", "retry", "theme", "expiration",
-                       "poll_interval", "trace"}
+                       "poll_interval", "trace", "dangerous_no_tls_verify"}
 DEFAULT_CONFIG = {
     "timeout": 10,
     "method": "get",
     "retry": 0,
-    "verify": True,
+    "verify": None,
     "cert": None,
     "name": None,
     "expiration": 600,
     "poll_interval": POLL_INTERVAL,
     "trace": None,
+    "dangerous_no_tls_verify": False,
 }
 
 PENDING = 0
@@ -132,15 +133,20 @@ class CloudStackException(Exception):
 
 class CloudStack(object):
     def __init__(self, endpoint, key, secret, timeout=10, method='get',
-                 verify=True, cert=None, name=None, retry=0,
+                 verify=None, cert=None, name=None, retry=0,
                  job_timeout=None, poll_interval=POLL_INTERVAL,
-                 expiration=timedelta(minutes=10), trace=False):
+                 expiration=timedelta(minutes=10), trace=False,
+                 dangerous_no_tls_verify=False):
         self.endpoint = endpoint
         self.key = key
         self.secret = secret
         self.timeout = int(timeout)
         self.method = method.lower()
-        self.verify = verify
+        if verify is not None:
+            self.verify = verify
+        else:
+            self.verify = not dangerous_no_tls_verify
+
         self.cert = cert
         self.name = name
         self.retry = int(retry)
@@ -434,12 +440,12 @@ def read_config(ini_group=None):
                          ", ".join(missings))
 
     # convert booleans values.
-    if isinstance(config['verify'], string_type):
-        try:
-            verify = strtobool(config['verify'])
-        except ValueError:
-            pass
-        else:
-            config['verify'] = verify
+    bool_keys = ('dangerous_no_tls_verify',)
+    for bool_key in bool_keys:
+        if isinstance(config[bool_key], string_type):
+            try:
+                config[bool_key] = strtobool(config[bool_key])
+            except ValueError:
+                pass
 
     return config

--- a/cs/client.py
+++ b/cs/client.py
@@ -9,6 +9,7 @@ import sys
 import re
 import time
 from datetime import datetime, timedelta
+from distutils.util import strtobool
 
 try:
     from configparser import ConfigParser
@@ -431,4 +432,14 @@ def read_config(ini_group=None):
     if missings:
         raise ValueError("the configuration is missing the following keys: "
                          ", ".join(missings))
+
+    # convert booleans values.
+    if isinstance(config['verify'], string_type):
+        try:
+            verify = strtobool(config['verify'])
+        except ValueError:
+            pass
+        else:
+            config['verify'] = verify
+
     return config

--- a/tests.py
+++ b/tests.py
@@ -124,6 +124,7 @@ class ConfigTest(TestCase):
                  CLOUDSTACK_KEY='test key from env',
                  CLOUDSTACK_SECRET='test secret from env',
                  CLOUDSTACK_REGION='hanibal',
+                 CLOUDSTACK_VERIFY='0',
                  CLOUDSTACK_OVERRIDES='endpoint,secret'), cwd('/tmp'):
             conf = read_config()
             self.assertEqual({
@@ -137,7 +138,7 @@ class ConfigTest(TestCase):
                 'poll_interval': 2.0,
                 'name': 'hanibal',
                 'poll_interval': 2.0,
-                'verify': True,
+                'verify': False,
                 'retry': 0,
                 'method': 'get',
                 'cert': None,
@@ -149,6 +150,7 @@ class ConfigTest(TestCase):
                     'endpoint = https://api.example.com/from-file\n'
                     'key = test key from file\n'
                     'secret = test secret from file\n'
+                    'verify = false\n'
                     'theme = monokai\n'
                     'other = please ignore me\n'
                     'timeout = 50')
@@ -167,7 +169,7 @@ class ConfigTest(TestCase):
                 'poll_interval': 2.0,
                 'name': 'cloudstack',
                 'poll_interval': 2.0,
-                'verify': True,
+                'verify': False,
                 'retry': 0,
                 'method': 'get',
                 'cert': None,

--- a/tests.py
+++ b/tests.py
@@ -79,7 +79,8 @@ class ConfigTest(TestCase):
                 'trace': None,
                 'timeout': 10,
                 'poll_interval': 2.0,
-                'verify': True,
+                'verify': None,
+                'dangerous_no_tls_verify': False,
                 'cert': None,
                 'name': None,
                 'retry': 0,
@@ -105,6 +106,7 @@ class ConfigTest(TestCase):
                 'poll_interval': 2.0,
                 'verify': '/path/to/ca.pem',
                 'cert': '/path/to/cert.pem',
+                'dangerous_no_tls_verify': False,
                 'name': None,
                 'retry': '5',
             }, conf)
@@ -124,7 +126,7 @@ class ConfigTest(TestCase):
                  CLOUDSTACK_KEY='test key from env',
                  CLOUDSTACK_SECRET='test secret from env',
                  CLOUDSTACK_REGION='hanibal',
-                 CLOUDSTACK_VERIFY='0',
+                 CLOUDSTACK_DANGEROUS_NO_TLS_VERIFY='1',
                  CLOUDSTACK_OVERRIDES='endpoint,secret'), cwd('/tmp'):
             conf = read_config()
             self.assertEqual({
@@ -138,7 +140,8 @@ class ConfigTest(TestCase):
                 'poll_interval': 2.0,
                 'name': 'hanibal',
                 'poll_interval': 2.0,
-                'verify': False,
+                'verify': None,
+                'dangerous_no_tls_verify': True,
                 'retry': 0,
                 'method': 'get',
                 'cert': None,
@@ -150,7 +153,7 @@ class ConfigTest(TestCase):
                     'endpoint = https://api.example.com/from-file\n'
                     'key = test key from file\n'
                     'secret = test secret from file\n'
-                    'verify = false\n'
+                    'dangerous_no_tls_verify = true\n'
                     'theme = monokai\n'
                     'other = please ignore me\n'
                     'timeout = 50')
@@ -169,7 +172,8 @@ class ConfigTest(TestCase):
                 'poll_interval': 2.0,
                 'name': 'cloudstack',
                 'poll_interval': 2.0,
-                'verify': False,
+                'verify': None,
+                'dangerous_no_tls_verify': True,
                 'retry': 0,
                 'method': 'get',
                 'cert': None,


### PR DESCRIPTION
This allows such configuration, which is mostly useful for special developer cases.

```ini
endpoint = https://192.168.1.1/compute
dangerous_no_tls_verify = false
```

http://docs.python-requests.org/en/master/user/advanced/?#ssl-cert-verification