### PR TITLE
Fix exception when fetch_results=True and trace=True

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -230,7 +230,7 @@ class CloudStack(object):
             if self.trace:
                 print(response.status_code, response.reason, file=sys.stderr)
                 headersTrace = "\n".join("{}: {}".format(k, v)
-                                    for k, v in response.headers.items())
+                                         for k, v in response.headers.items())
                 print(headersTrace, "\n", file=sys.stderr)
                 print(response.text, "\n", file=sys.stderr)
 

--- a/cs/client.py
+++ b/cs/client.py
@@ -229,9 +229,9 @@ class CloudStack(object):
 
             if self.trace:
                 print(response.status_code, response.reason, file=sys.stderr)
-                headers = "\n".join("{}: {}".format(k, v)
+                headersTrace = "\n".join("{}: {}".format(k, v)
                                     for k, v in response.headers.items())
-                print(headers, "\n", file=sys.stderr)
+                print(headersTrace, "\n", file=sys.stderr)
                 print(response.text, "\n", file=sys.stderr)
 
             data = self._response_value(response, json)


### PR DESCRIPTION
When you set up trace=True and try to launch async call with fetch_result, you'll get the following exception in _jobresult() method:
AttributeError: 'str' object has no attribute 'items'

This is caused by overwriting "headers" variable in _request() method when tracing is enabled. 
As a result, headers are passed to _jobresult() as a string. 
The solution is to rename headers variable in self.trace ifblock to something else.
