### PR TITLE
client: refactor exceptions

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -98,6 +98,8 @@ def main(args=None):
         config['trace'] = True
     cs = CloudStack(**config)
     ok = True
+    response = None
+
     try:
         response = getattr(cs, command)(fetch_result=fetch_result,
                                         **kwargs)
@@ -105,8 +107,9 @@ def main(args=None):
         ok = False
         if e.response is not None:
             if not options.quiet:
-                sys.stderr.write("Cloudstack error: HTTP response "
-                                 "{0}\n".format(e.response.status_code))
+                sys.stderr.write("CloudStack error: ")
+                sys.stderr.write("\n".join(e.args))
+                sys.stderr.write("\n")
 
             try:
                 response = json.loads(e.response.text)

--- a/cs/client.py
+++ b/cs/client.py
@@ -272,19 +272,26 @@ class CloudStack(object):
             contentType = response.headers.get("Content-Type", "")
             if not contentType.startswith(("application/json",
                                            "text/javascript")):
+                if response.status_code == 200:
+                    raise CloudStackException(
+                        "JSON (application/json) was expected, got {!r}"
+                        .format(contentType),
+                        response=response)
+
                 raise CloudStackException(
-                    "JSON (application/json) was expected, got {!r}"
-                    .format(contentType),
+                    "HTTP {0.status_code} {0.reason}"
+                    .format(response),
+                    "Make sure endpoint URL {!r} is correct."
+                    .format(self.endpoint),
                     response=response)
 
             try:
                 data = response.json()
             except ValueError as e:
-                msg = "Make sure endpoint URL '%s' is correct." % self.endpoint
                 raise CloudStackException(
-                    "HTTP {0} response from CloudStack"
-                    .format(response.status_code),
-                    "%s. " % str(e) + msg,
+                    "HTTP {0.status_code} {0.reason}"
+                    .format(response),
+                    "{0!s}. Malformed JSON document".format(e),
                     response=response)
 
             [key] = data.keys()


### PR DESCRIPTION
When the error occurs before reaching CloudStack, the reason is often hidden by the fact that the answer isn't in the expected application/json

**Before**

```python
cs.deployVirtualMachine(userdata="...")
```

> CloudStackException("JSON (application/json) was expected, got 'text/html'")


**After**

```python
cs.deployVirtualMachine(userdata="...")
```

> CloudStackException('HTTP 414 Request-URI Too Large', "Make sure endpoint URL 'https://ppapi.exoscale.ch/compute' is correct.")
