### PR TITLE
FIX: job_timeout should be None if not specified => wait forever

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -151,7 +151,7 @@ class CloudStack(object):
         self.cert = cert
         self.name = name
         self.retry = int(retry)
-        self.job_timeout = int(job_timeout) if job_timeout else 0
+        self.job_timeout = int(job_timeout) if job_timeout else None
         self.poll_interval = float(poll_interval)
         if not hasattr(expiration, "seconds"):
             expiration = timedelta(seconds=int(expiration))


### PR DESCRIPTION
In README we specify that if we do not set job_timeout, we will wait forever.
But we was defaulting to 0 => do not wait at all