### PR TITLE
tox: skip missing interpreters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
 	py{27,34,35,36,37,38}
 	lint
+skip_missing_interpreters = True
 
 [travis]
 python =


### PR DESCRIPTION
@chrisglass' life will be even smoother now

E.g. with the very lousy distro of mine.

```
  py27: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
SKIPPED:  py38: InterpreterNotFound: python3.8
  lint: commands succeeded
  congratulations :)
```