### PR TITLE
cli: fix error on errors

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -108,7 +108,7 @@ def main(args=None):
         if e.response is not None:
             if not options.quiet:
                 sys.stderr.write("CloudStack error: ")
-                sys.stderr.write("\n".join(e.args))
+                sys.stderr.write("\n".join((str(arg) for arg in e.args)))
                 sys.stderr.write("\n")
 
             try:


### PR DESCRIPTION
silly traceback...

```
cs.client.CloudStackException: ('HTTP 401 response from CloudStack', {'errorcode': 401, 'errortext': 'unable to verify user credentials and/or request signature', 'uuidList': []})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yoan/.local/bin/cs", line 10, in <module>
    sys.exit(main())
  File "/home/yoan/.local/lib/python3.7/site-packages/cs/__init__.py", line 111, in main
    sys.stderr.write("\n".join(e.args))
TypeError: sequence item 1: expected str instance, dict found
```

**then**

```
CloudStack error: HTTP 401 response from CloudStack
{'errorcode': 401, 'errortext': 'unable to verify user credentials and/or request signature', 'uuidList': []}
```
```json
{
  "errorresponse": {
    "errorcode": 401,
    "errortext": "unable to verify user credentials and/or request signature",
    "uuidList": []
  }
}
```