### PR TITLE
Add support for custom HTTP request headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 build
+.venv
 .coverage
 .eggs
 .tox

--- a/cs/client.py
+++ b/cs/client.py
@@ -460,7 +460,7 @@ def read_config_from_ini(ini_group=None):
         if k.startswith("header_"):
             if "headers" not in ini_config.keys():
                 ini_config["headers"] = {}
-            ini_config["headers"][k.replace("header_", "")] = ini_config.pop(k)
+            ini_config["headers"][k[len("header_"):]] = ini_config.pop(k)
     return ini_config
 
 

--- a/cs/client.py
+++ b/cs/client.py
@@ -456,7 +456,7 @@ def read_config_from_ini(ini_group=None):
     ini_config["name"] = ini_group
 
     # Convert individual header_* settings into a single dict
-    for k in ini_config.copy():
+    for k in list(ini_config):
         if k.startswith("header_"):
             if "headers" not in ini_config.keys():
                 ini_config["headers"] = {}

--- a/cs/client.py
+++ b/cs/client.py
@@ -448,9 +448,11 @@ def read_config_from_ini(ini_group=None):
         if not conf.has_section(ini_group):
             return dict(name=None)
 
-    ini_config = {k: v
-                  for k, v in conf.items(ini_group)
-                  if v and check_key(k, REQUIRED_CONFIG_KEYS.union(ALLOWED_CONFIG_KEYS))}
+    ini_config = {
+        k: v
+        for k, v in conf.items(ini_group)
+        if v and check_key(k, REQUIRED_CONFIG_KEYS.union(ALLOWED_CONFIG_KEYS))
+    }
     ini_config["name"] = ini_group
 
     # Convert individual header_* settings into a single dict

--- a/tests.py
+++ b/tests.py
@@ -141,6 +141,8 @@ class ConfigTest(TestCase):
                     'dangerous_no_tls_verify = true\n'
                     'theme = monokai\n'
                     'other = please ignore me\n'
+                    'header_x-custom-header1 = foo\n'
+                    'header_x-custom-header2 = bar\n'
                     'timeout = 50')
             self.addCleanup(partial(os.remove, '/tmp/cloudstack.ini'))
 
@@ -162,6 +164,10 @@ class ConfigTest(TestCase):
                 'retry': 0,
                 'method': 'get',
                 'cert': None,
+                'headers': {
+                    'x-custom-header1': 'foo',
+                    'x-custom-header2': 'bar',
+                },
             }, conf)
 
     def test_incomplete_config(self):


### PR DESCRIPTION
This change adds support for user-defined arbitrary headers to be
injected to every outgoing HTTP request to the Exoscale API.
Configuration is done through a new `header_<NAME>` key in the
`cloudstack.ini` file:

```ini
[cloudstack]
endpoint = https://api.exoscale.ch/compute
key = EXO************************
secret = *******************************************
timeout = 60
header_X-Custom-Header1 = foo
header_X-Custom-Header2 = bar
```

Story: [The cs library should allow adding arbitrary headers](https://app.clubhouse.io/exoscale/story/2542)