### PR TITLE
Add built-in implementation of strtobool

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -9,7 +9,6 @@ import re
 import sys
 import time
 from datetime import datetime, timedelta
-from distutils.util import strtobool
 from fnmatch import fnmatch
 
 try:
@@ -73,6 +72,25 @@ DEFAULT_CONFIG = {
 PENDING = 0
 SUCCESS = 1
 FAILURE = 2
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    This function has been borrowed from distutils.util module in order
+    to avoid pulling a dependency on deprecated module "imp".
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def check_key(key, allowed):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps=
 	flake8
 	flake8-import-order
 commands =
+	pip install pytest pytest-cache pytest-cov
 	python setup.py test
 	check-manifest
 	lint: flake8 cs tests.py


### PR DESCRIPTION
This change adds a built-in implementation of the `strtobool()` function
from the `distutils.util` module to avoid pulling a dependency on
deprecated module `imp`.