### PR TITLE
exceptions: introduce an exception subclass for API errors

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     pygments = None
 
-from .client import read_config, CloudStack, CloudStackException  # noqa
+from .client import read_config, CloudStack, CloudStackApiException, CloudStackException  # noqa
 
 
 __all__ = ['read_config', 'CloudStack', 'CloudStackException']


### PR DESCRIPTION
This allows easy access to the underlying API error, whether we're in an
async job context or a synchronous API call.