### PR TITLE
introduce client-level fetch_result

### DIFF
--- a/cs/_async.py
+++ b/cs/_async.py
@@ -1,6 +1,5 @@
 import asyncio
 import ssl
-import warnings
 
 import aiohttp
 
@@ -16,11 +15,7 @@ class AIOCloudStack(CloudStack):
 
     async def _request(self, command, json=True, opcode_name='command',
                        fetch_list=False, headers=None, **params):
-        if "fetch_result" not in params:
-            warnings.warn("implicit job polling is deprecated. To pull the "
-                          "job result in future releases, please pass "
-                          "fetch_result=True")
-        fetch_result = params.pop("fetch_result", True)
+        fetch_result = params.pop("fetch_result", self.fetch_result)
         kwarg, kwargs = self._prepare_request(command, json, opcode_name,
                                               fetch_list, **params)
 

--- a/cs/client.py
+++ b/cs/client.py
@@ -173,7 +173,8 @@ class CloudStack(object):
                  verify=None, cert=None, name=None, retry=0,
                  job_timeout=None, poll_interval=POLL_INTERVAL,
                  expiration=timedelta(minutes=10), trace=False,
-                 dangerous_no_tls_verify=False, headers=None):
+                 dangerous_no_tls_verify=False, headers=None,
+                 fetch_result=False):
         self.endpoint = endpoint
         self.key = key
         self.secret = secret
@@ -195,6 +196,7 @@ class CloudStack(object):
             expiration = timedelta(seconds=int(expiration))
         self.expiration = expiration
         self.trace = bool(trace)
+        self.fetch_result = fetch_result
 
     def __repr__(self):
         return '<CloudStack: {0}>'.format(self.name or self.endpoint)
@@ -226,7 +228,7 @@ class CloudStack(object):
 
     def _request(self, command, json=True, opcode_name='command',
                  fetch_list=False, headers=None, **params):
-        fetch_result = params.pop('fetch_result', False)
+        fetch_result = params.pop('fetch_result', self.fetch_result)
         kind, params = self._prepare_request(command, json, opcode_name,
                                              fetch_list, **params)
         if headers is None:


### PR DESCRIPTION
This allows passing `fetch_result=True` to a cs client for it to poll
all async jobs by default, instead of having to pass the parameter to
individual API calls.