### PR TITLE
Better API Exception rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 
 language: python
 python:
-  - 2.7
-  - 3.5
   - 3.6
   - 3.7
   - 3.8-dev

--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -18,10 +18,11 @@ except ImportError:
     pygments = None
 
 from .client import (
-    read_config,
     CloudStack,
     CloudStackApiException,
-    CloudStackException )  # noqa
+    CloudStackException,
+    read_config
+)
 
 
 __all__ = ['read_config', 'CloudStack', 'CloudStackException',

--- a/cs/client.py
+++ b/cs/client.py
@@ -173,6 +173,12 @@ class CloudStackApiException(CloudStackException):
         self.error = kwargs.pop('error')
         super(CloudStackApiException, self).__init__(*args, **kwargs)
 
+    def __str__(self):
+        return '{0}, error: {1}'.format(
+            super(CloudStackApiException, self).__str__(),
+            self.error
+        )
+
 
 class CloudStack(object):
     def __init__(self, endpoint, key, secret, timeout=10, method='get',

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,12 @@ try:
 except ImportError:
     from urlparse import urlparse, parse_qs
 
-from cs import CloudStack, CloudStackException, read_config
+from cs import (
+    CloudStack,
+    CloudStackApiException,
+    CloudStackException,
+    read_config
+)
 from cs.client import EXPIRES_FORMAT
 
 from requests.structures import CaseInsensitiveDict
@@ -47,6 +52,15 @@ def cwd(path):
             yield
     finally:
         os.chdir(initial)
+
+
+class ExceptionTest(TestCase):
+
+    def test_api_exception_str(self):
+        e = CloudStackApiException("CS failed",
+                                   error={"test": 42},
+                                   response=None)
+        self.assertEqual("CS failed, error: {'test': 42}", str(e))
 
 
 class ConfigTest(TestCase):


### PR DESCRIPTION
While investigating compute-tests failures, we faced poor `HTTP 431 response from CloudStack` exceptions which do not expose the `error` field. This PR makes overrides the `__str__` method so that we expose the error field so we will see it in CI.

Travis is not working anymore, but I run `tox` locally which includes tests and linters, and they work fine. I only had to comment out `27` in the `tox` file as there is one place which ruins Python 2 support.
