### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ dist: xenial
 sudo: required
 
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
   - 3.6
   - 3.7


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/cs/builds/207335206
Please have a look.

Regards,
ujjwal