### PR TITLE
migrate from pytz to zoneinfo

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -9,8 +9,7 @@ from configparser import ConfigParser
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
 from urllib.parse import quote
-
-import pytz
+from zoneinfo import ZoneInfo
 
 import requests
 from requests.structures import CaseInsensitiveDict
@@ -245,8 +244,9 @@ class CloudStack(object):
             params.setdefault("pagesize", PAGE_SIZE)
         if "expires" not in params and self.expiration.total_seconds() >= 0:
             params["signatureVersion"] = "3"
-            tz = pytz.utc
-            expires = tz.localize(datetime.utcnow() + self.expiration)
+            tz = ZoneInfo("UTC")
+            expires = datetime.utcnow() + self.expiration
+            expires = expires.replace(tzinfo=tz)
             params["expires"] = expires.astimezone(tz).strftime(EXPIRES_FORMAT)
 
         kind = "params" if self.method == "get" else "data"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    pytz
     requests
 
 [options.packages.find]


### PR DESCRIPTION
With dropping py < 3.9 support we can now move from pytz to zoneinfo which is part of stdlib from 3.9