### PR TITLE
fix f-string bug in Error-Message

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -352,7 +352,7 @@ class CloudStack(object):
             if not ctype.startswith(("application/json", "text/javascript")):
                 if response.status_code == 200:
                     msg = (
-                        f"JSON (application/json) was expected, got {ctype:!r}"
+                        f"JSON (application/json) was expected, got {ctype!r}"
                     )
                     raise CloudStackException(msg, response=response)
 


### PR DESCRIPTION
fix following error:

```
  File "/app/.venv/lib/python3.14/site-packages/cs/client.py", line 355, in _response_value
    f"JSON (application/json) was expected, got {ctype:!r}"
                                                ^^^^^^^^^^
ValueError: Invalid format specifier '!r' for object of type 'str'
```