### PR TITLE
Fix missing arguments in CloudStackApiException raise

### DIFF
--- a/cs/client.py
+++ b/cs/client.py
@@ -371,7 +371,9 @@ class CloudStack(object):
 
         if response.status_code != 200:
             raise CloudStackApiException(
-                f"HTTP {response.status_code} response from CloudStack"
+                f"HTTP {response.status_code} response from CloudStack",
+                error=data,
+                response=response,
             )
 
         return data


### PR DESCRIPTION
Fix removed arguments removed in [ commit `ad60009d48a226e5bf851cdc0a2628755bb46d4c`](https://github.com/ngine-io/cs/commit/ad60009d48a226e5bf851cdc0a2628755bb46d4c#diff-6221108d31aef27fc7402b2357378a23a6bf810dae9ce07425742980109f0bc4R373)